### PR TITLE
Removed SDK Version

### DIFF
--- a/lcpshim/Makefile
+++ b/lcpshim/Makefile
@@ -1,4 +1,3 @@
-TARGET = iphone:clang:15.5:13.0
 ARCHS = arm64
 FINALPACKAGE = 1
 include $(THEOS)/makefiles/common.mk


### PR DESCRIPTION
I removed `TARGET = iphone:clang:15.5:13.0` in the **Alderis/Icpshim/makefile** because it was just unnecessary to have when we already got it in **Alderis/makefile**.